### PR TITLE
fix: don't use BufReader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libsbf"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["sbf-parser-fuzz"] }
 [package]
 name = "libsbf"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A no_std rust crate to parse Septentrio SBF Messages."


### PR DESCRIPTION
The sans-io core parser is essentially a BufReader so there is no need to create an extra BufReader. Instead just make an iterator over anything that implements Read and try to read huge amounts of data.