### PR TITLE
feat: add initial IMUSetup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ define_messages!(
     AttEuler => 5938,
     ExtSensorMeas => 4050,
     QualityInd => 4082,
+    ImuSetup => 4224,
 );
 
 // Attitude Euler Block 5938
@@ -386,6 +387,31 @@ pub struct INSNavGeodAttCov {
     pub heading_roll_cov: Option<f32>,
     #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
     pub pitch_roll_cov: Option<f32>,
+}
+
+// IMU Setup Block 4224
+#[binrw]
+#[derive(Debug)]
+pub struct ImuSetup {
+    #[br(map = |x| if x == DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x| if x == DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    _reserved: u8,
+    // TODO: create SerialPort enum for future serial port info
+    pub serial_port: u8,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub ant_lever_arm_x_m: Option<f32>,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub ant_lever_arm_y_m: Option<f32>,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub ant_lever_arm_z_m: Option<f32>,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub theta_x_deg: Option<f32>,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub theta_y_deg: Option<f32>,
+    #[br(map = |x| if x == DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub theta_z_deg: Option<f32>,
 }
 
 pub fn is_sync(bytes: &[u8; 2]) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use binrw::io::Cursor;
 use binrw::BinRead;
 
-use crate::{Header, MessageKind, Messages, AttEuler, INSNavGeod, ExtSensorMeas, QualityInd};
+use crate::{Header, MessageKind, Messages, AttEuler, INSNavGeod, ExtSensorMeas, QualityInd, ImuSetup};
 
 use crc16::*;
 
@@ -106,6 +106,11 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
             let mut body_cursor = Cursor::new(payload.as_slice());
             let ext_sensor_meas = ExtSensorMeas::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
             Messages::ExtSensorMeas(ext_sensor_meas)
+        }
+        MessageKind::ImuSetup => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let imu_setup = ImuSetup::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ImuSetup(imu_setup)
         }
         _ => {
             // should never end up in here since we

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -126,6 +126,11 @@ mod tests {
                     let expected = cf_lines.next().unwrap()?;
                     assert!(parsed == expected, "parsed line: {} did not match expected line: {}", parsed, expected);
                 }
+                // Messages::ImuSetup(imu_setup) => {
+                //     let parsed = format!("{:?}",imu_setup);
+                //     let expected = cf_lines.next().unwrap()?;
+                //     assert!(parsed == expected, "parsed line: {} did not match expected line: {}", parsed, expected);
+                // }
                 _ => continue
             }
         }


### PR DESCRIPTION
Adds parsing for the IMUSetup type
```
IMUSetup is: Some((ImuSetup { tow: None, wnc: None, _reserved: 0, serial_port: 32, ant_lever_arm_x_m: Some(0.007), ant_lever_arm_y_m: Some(0.448), ant_lever_arm_z_m: Some(-0.119), theta_x_deg: Some(180.0), theta_y_deg: Some(0.0), theta_z_deg: Some(90.0) }, 2025-07-01T14:39:18.509439257Z))
```

Caveats
Didn't implement testing within libsbf-rs for the new type