### PR TITLE
fix: properly handle EOF failure case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libsbf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["sbf-parser-fuzz"] }
 [package]
 name = "libsbf"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A no_std rust crate to parse Septentrio SBF Messages."

--- a/README.md
+++ b/README.md
@@ -13,4 +13,8 @@ nix develop
 cd sbf-parser-fuzz
 cargo afl build --release
 cargo afl fuzz -i in -o out ../target/release/sbf-parser-fuzz
+
+## fuzz testing std iterator
+cargo afl build --bin reader-fuzz --release
+cargo afl fuzz -i in -o out ../target/release/sbf-parser-fuzz
 ```

--- a/sbf-parser-fuzz/Cargo.toml
+++ b/sbf-parser-fuzz/Cargo.toml
@@ -7,4 +7,8 @@ edition = "2021"
 
 [dependencies]
 afl = "0.15.17"
-libsbf = { path = ".." }
+libsbf = { path = "..", features = [ "std" ] }
+
+[[bin]]
+name = "reader-fuzz"
+path = "src/reader-fuzz.rs"

--- a/sbf-parser-fuzz/src/reader-fuzz.rs
+++ b/sbf-parser-fuzz/src/reader-fuzz.rs
@@ -1,0 +1,90 @@
+use afl::*;
+use std::io::Read;
+
+use libsbf::reader::SbfReader;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        // Test with the original fuzz data
+        test_sbf_reader(data);
+        
+        // Also test with larger data to catch buffer-related bugs
+        if (0..20000).contains(&data.len()) {
+            // Create a larger test case by repeating the data
+            let mut large_data = Vec::new();
+            while large_data.len() < 20000 {
+                large_data.extend_from_slice(data);
+            }
+            test_sbf_reader(&large_data);
+        }
+    });
+}
+
+fn test_sbf_reader(data: &[u8]) {
+    // Create a simple reader from the fuzz data
+    let mut reader = FuzzReader::new(data);
+    let total_bytes = reader.len();
+    
+    // Skip empty data
+    if total_bytes == 0 {
+        return;
+    }
+    
+    // Process all messages from the SbfReader
+    let sbf_reader = SbfReader::new(&mut reader);
+    let mut message_count = 0;
+    
+    for result in sbf_reader {
+        match result {
+            Ok(_msg) => {
+                message_count += 1;
+            }
+            Err(_) => {
+                // Errors are expected with random data, but shouldn't panic
+            }
+        }
+    }
+    
+    // The reader should have consumed all the data
+    let bytes_consumed = reader.bytes_read();
+    assert_eq!(bytes_consumed, total_bytes, 
+        "SbfReader did not consume all {} bytes of fuzz data, only consumed {}", 
+        total_bytes, bytes_consumed);
+}
+
+// A simple reader that provides all fuzz data at once
+struct FuzzReader {
+    data: Vec<u8>,
+    position: usize,
+}
+
+impl FuzzReader {
+    fn new(data: &[u8]) -> Self {
+        Self {
+            data: data.to_vec(),
+            position: 0,
+        }
+    }
+    
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+    
+    fn bytes_read(&self) -> usize {
+        self.position
+    }
+}
+
+impl Read for FuzzReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = self.data.len() - self.position;
+        let to_read = buf.len().min(remaining);
+        
+        if to_read > 0 {
+            buf[..to_read].copy_from_slice(&self.data[self.position..self.position + to_read]);
+            self.position += to_read;
+        }
+        
+        Ok(to_read)
+    }
+}


### PR DESCRIPTION
Currently the iterator would set `is_eof` to true on every call to read. It should only do this when the bytes read is 0. We would only see this on large buffers of non-parseable messages. Also added a fuzz test for the std iterator and a unit test to catch this specific bug.