### PR TITLE
chore: bump crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["sbf-parser-fuzz"] }
 [package]
 name = "libsbf"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A no_std rust crate to parse Septentrio SBF Messages."


### PR DESCRIPTION
Bump the crate version after having implemented and tested all the new messages previously merged.