### PR TITLE
chore: de-duplicate some stuff

### DIFF
--- a/src/messages/ext_sensor_info.rs
+++ b/src/messages/ext_sensor_info.rs
@@ -16,42 +16,6 @@ pub struct ExtSensorInfo {
 }
 
 impl ExtSensorInfo {
-    // Source constants (same as ExtSensorStatus)
-    pub const SOURCE_COM1: u8 = 0;
-    pub const SOURCE_COM2: u8 = 1;
-    pub const SOURCE_COM3: u8 = 2;
-    pub const SOURCE_COM4: u8 = 3;
-    pub const SOURCE_GPIO: u8 = 4;
-    pub const SOURCE_USB1: u8 = 5;
-    pub const SOURCE_USB2: u8 = 6;
-    pub const SOURCE_IP10: u8 = 7;
-    pub const SOURCE_IP11: u8 = 8;
-    pub const SOURCE_IP12: u8 = 9;
-    pub const SOURCE_IP13: u8 = 10;
-    pub const SOURCE_IP14: u8 = 11;
-    pub const SOURCE_IP15: u8 = 12;
-    pub const SOURCE_IP16: u8 = 13;
-    pub const SOURCE_IP17: u8 = 14;
-    pub const SOURCE_IPS1: u8 = 15;
-    pub const SOURCE_IPS2: u8 = 16;
-    pub const SOURCE_IPS3: u8 = 17;
-    pub const SOURCE_IPS4: u8 = 18;
-    pub const SOURCE_IPS5: u8 = 19;
-    pub const SOURCE_IPR1: u8 = 20;
-    pub const SOURCE_IPR2: u8 = 21;
-    pub const SOURCE_IPR3: u8 = 22;
-    pub const SOURCE_IPR4: u8 = 23;
-    pub const SOURCE_IPR5: u8 = 24;
-    pub const SOURCE_INTERNAL_SPI: u8 = 32;
-
-    // Sensor model constants (same as ExtSensorStatus)
-    pub const MODEL_SBG_ELLIPSE: u8 = 2;
-    pub const MODEL_SBG_ELLIPSE2: u8 = 5;
-    pub const MODEL_VN100: u8 = 7;
-    pub const MODEL_ADIS1650X: u8 = 10;
-    pub const MODEL_ZERO_VELOCITY: u8 = 20;
-    pub const MODEL_VELOCITY_INPUT: u8 = 21;
-
     // Data structure sizes
     pub const SBG_DATA_SIZE: usize = 52;
     pub const VN100_DATA_SIZE: usize = 36;

--- a/src/messages/ext_sensor_status.rs
+++ b/src/messages/ext_sensor_status.rs
@@ -1,5 +1,153 @@
 use alloc::vec::Vec;
 use binrw::binrw;
+use core::fmt;
+
+/// Connection port / external sensor source.
+///
+/// Used by ExtSensorStatus, ExtSensorInfo, and VelSensorSetup to identify the
+/// receiver port an external sensor is connected to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum ConnectionPort {
+    #[default]
+    Com1 = 0,
+    Com2 = 1,
+    Com3 = 2,
+    Com4 = 3,
+    Gpio = 4,
+    Usb1 = 5,
+    Usb2 = 6,
+    Ip10 = 7,
+    Ip11 = 8,
+    Ip12 = 9,
+    Ip13 = 10,
+    Ip14 = 11,
+    Ip15 = 12,
+    Ip16 = 13,
+    Ip17 = 14,
+    Ips1 = 15,
+    Ips2 = 16,
+    Ips3 = 17,
+    Ips4 = 18,
+    Ips5 = 19,
+    Ipr1 = 20,
+    Ipr2 = 21,
+    Ipr3 = 22,
+    Ipr4 = 23,
+    Ipr5 = 24,
+    InternalSpi = 32,
+    Unknown,
+}
+
+impl From<u8> for ConnectionPort {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => ConnectionPort::Com1,
+            1 => ConnectionPort::Com2,
+            2 => ConnectionPort::Com3,
+            3 => ConnectionPort::Com4,
+            4 => ConnectionPort::Gpio,
+            5 => ConnectionPort::Usb1,
+            6 => ConnectionPort::Usb2,
+            7 => ConnectionPort::Ip10,
+            8 => ConnectionPort::Ip11,
+            9 => ConnectionPort::Ip12,
+            10 => ConnectionPort::Ip13,
+            11 => ConnectionPort::Ip14,
+            12 => ConnectionPort::Ip15,
+            13 => ConnectionPort::Ip16,
+            14 => ConnectionPort::Ip17,
+            15 => ConnectionPort::Ips1,
+            16 => ConnectionPort::Ips2,
+            17 => ConnectionPort::Ips3,
+            18 => ConnectionPort::Ips4,
+            19 => ConnectionPort::Ips5,
+            20 => ConnectionPort::Ipr1,
+            21 => ConnectionPort::Ipr2,
+            22 => ConnectionPort::Ipr3,
+            23 => ConnectionPort::Ipr4,
+            24 => ConnectionPort::Ipr5,
+            32 => ConnectionPort::InternalSpi,
+            _ => ConnectionPort::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for ConnectionPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectionPort::Com1 => write!(f, "COM1"),
+            ConnectionPort::Com2 => write!(f, "COM2"),
+            ConnectionPort::Com3 => write!(f, "COM3"),
+            ConnectionPort::Com4 => write!(f, "COM4"),
+            ConnectionPort::Gpio => write!(f, "GPIO"),
+            ConnectionPort::Usb1 => write!(f, "USB1"),
+            ConnectionPort::Usb2 => write!(f, "USB2"),
+            ConnectionPort::Ip10 => write!(f, "IP10"),
+            ConnectionPort::Ip11 => write!(f, "IP11"),
+            ConnectionPort::Ip12 => write!(f, "IP12"),
+            ConnectionPort::Ip13 => write!(f, "IP13"),
+            ConnectionPort::Ip14 => write!(f, "IP14"),
+            ConnectionPort::Ip15 => write!(f, "IP15"),
+            ConnectionPort::Ip16 => write!(f, "IP16"),
+            ConnectionPort::Ip17 => write!(f, "IP17"),
+            ConnectionPort::Ips1 => write!(f, "IPS1"),
+            ConnectionPort::Ips2 => write!(f, "IPS2"),
+            ConnectionPort::Ips3 => write!(f, "IPS3"),
+            ConnectionPort::Ips4 => write!(f, "IPS4"),
+            ConnectionPort::Ips5 => write!(f, "IPS5"),
+            ConnectionPort::Ipr1 => write!(f, "IPR1"),
+            ConnectionPort::Ipr2 => write!(f, "IPR2"),
+            ConnectionPort::Ipr3 => write!(f, "IPR3"),
+            ConnectionPort::Ipr4 => write!(f, "IPR4"),
+            ConnectionPort::Ipr5 => write!(f, "IPR5"),
+            ConnectionPort::InternalSpi => write!(f, "Internal SPI"),
+            ConnectionPort::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+/// External sensor model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum ExtSensorModel {
+    #[default]
+    Unknown = 0,
+    SbgEllipse = 2,
+    SbgEllipse2 = 5,
+    Vn100 = 7,
+    Adis1650x = 10,
+    ZeroVelocity = 20,
+    VelocityInput = 21,
+}
+
+impl From<u8> for ExtSensorModel {
+    fn from(value: u8) -> Self {
+        match value {
+            2 => ExtSensorModel::SbgEllipse,
+            5 => ExtSensorModel::SbgEllipse2,
+            7 => ExtSensorModel::Vn100,
+            10 => ExtSensorModel::Adis1650x,
+            20 => ExtSensorModel::ZeroVelocity,
+            21 => ExtSensorModel::VelocityInput,
+            _ => ExtSensorModel::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for ExtSensorModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExtSensorModel::Unknown => write!(f, "Unknown"),
+            ExtSensorModel::SbgEllipse => write!(f, "SBG Ellipse"),
+            ExtSensorModel::SbgEllipse2 => write!(f, "SBG Ellipse 2"),
+            ExtSensorModel::Vn100 => write!(f, "VN-100"),
+            ExtSensorModel::Adis1650x => write!(f, "ADIS1650x"),
+            ExtSensorModel::ZeroVelocity => write!(f, "Zero Velocity"),
+            ExtSensorModel::VelocityInput => write!(f, "Velocity Input"),
+        }
+    }
+}
 
 // ExtSensorStatus Block 4223
 #[binrw]
@@ -16,42 +164,6 @@ pub struct ExtSensorStatus {
 }
 
 impl ExtSensorStatus {
-    // Source constants
-    pub const SOURCE_COM1: u8 = 0;
-    pub const SOURCE_COM2: u8 = 1;
-    pub const SOURCE_COM3: u8 = 2;
-    pub const SOURCE_COM4: u8 = 3;
-    pub const SOURCE_GPIO: u8 = 4;
-    pub const SOURCE_USB1: u8 = 5;
-    pub const SOURCE_USB2: u8 = 6;
-    pub const SOURCE_IP10: u8 = 7;
-    pub const SOURCE_IP11: u8 = 8;
-    pub const SOURCE_IP12: u8 = 9;
-    pub const SOURCE_IP13: u8 = 10;
-    pub const SOURCE_IP14: u8 = 11;
-    pub const SOURCE_IP15: u8 = 12;
-    pub const SOURCE_IP16: u8 = 13;
-    pub const SOURCE_IP17: u8 = 14;
-    pub const SOURCE_IPS1: u8 = 15;
-    pub const SOURCE_IPS2: u8 = 16;
-    pub const SOURCE_IPS3: u8 = 17;
-    pub const SOURCE_IPS4: u8 = 18;
-    pub const SOURCE_IPS5: u8 = 19;
-    pub const SOURCE_IPR1: u8 = 20;
-    pub const SOURCE_IPR2: u8 = 21;
-    pub const SOURCE_IPR3: u8 = 22;
-    pub const SOURCE_IPR4: u8 = 23;
-    pub const SOURCE_IPR5: u8 = 24;
-    pub const SOURCE_INTERNAL_SPI: u8 = 32;
-
-    // Sensor model constants
-    pub const MODEL_SBG_ELLIPSE: u8 = 2;
-    pub const MODEL_SBG_ELLIPSE2: u8 = 5;
-    pub const MODEL_VN100: u8 = 7;
-    pub const MODEL_ADIS1650X: u8 = 10;
-    pub const MODEL_ZERO_VELOCITY: u8 = 20;
-    pub const MODEL_VELOCITY_INPUT: u8 = 21;
-
     // ADIS1650x status flags (byte 0)
     pub const ADIS_ERROR: u8 = 0x01;
     pub const ADIS_SENSOR_FAILURE: u8 = 0x02;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -41,7 +41,7 @@ pub use ext_sensor_meas::{
     ExtSensorMeas, ExtSensorMeasAcceleration, ExtSensorMeasAngularRate, ExtSensorMeasInfo,
     ExtSensorMeasSet, ExtSensorMeasSetType, ExtSensorMeasVelocity, ExtSensorMeasZeroVelocityFlag,
 };
-pub use ext_sensor_status::ExtSensorStatus;
+pub use ext_sensor_status::{ConnectionPort, ExtSensorModel, ExtSensorStatus};
 pub use gal_gst_gps::GALGstGps;
 pub use gal_ion::GALIon;
 pub use gal_nav::GALNav;

--- a/src/messages/pos_cov_geodetic.rs
+++ b/src/messages/pos_cov_geodetic.rs
@@ -1,5 +1,7 @@
 use binrw::binrw;
 
+use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
+
 // PosCovGeodetic Block 5906
 #[binrw]
 #[derive(Debug)]
@@ -8,8 +10,8 @@ pub struct PosCovGeodetic {
     pub tow: Option<u32>,
     #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
     pub wnc: Option<u16>,
-    pub mode: u8,
-    pub error: u8,
+    mode_raw: u8,
+    error_raw: u8,
     #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub cov_latlat: Option<f32>,
     #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
@@ -33,28 +35,18 @@ pub struct PosCovGeodetic {
 }
 
 impl PosCovGeodetic {
-    // Mode bits 0-3: PVT solution type
-    pub const MODE_NO_PVT: u8 = 0;
-    pub const MODE_STANDALONE: u8 = 1;
-    pub const MODE_DIFFERENTIAL: u8 = 2;
-    pub const MODE_FIXED: u8 = 3;
-    pub const MODE_RTK_FIXED: u8 = 4;
-    pub const MODE_RTK_FLOAT: u8 = 5;
-    pub const MODE_SBAS: u8 = 6;
-    pub const MODE_MOVING_BASE_RTK_FIXED: u8 = 7;
-    pub const MODE_MOVING_BASE_RTK_FLOAT: u8 = 8;
-    pub const MODE_PPP: u8 = 10;
+    /// PVT mode (bits 0-3 of mode).
+    pub fn pvt_mode(&self) -> PvtMode {
+        PvtMode::from(self.mode_raw)
+    }
 
-    // Error codes
-    pub const ERROR_NONE: u8 = 0;
-    pub const ERROR_NOT_ENOUGH_MEAS: u8 = 1;
-    pub const ERROR_NOT_ENOUGH_EPH: u8 = 2;
-    pub const ERROR_DOP_TOO_LARGE: u8 = 3;
-    pub const ERROR_RESIDUALS_TOO_LARGE: u8 = 4;
-    pub const ERROR_NO_CONVERGENCE: u8 = 5;
-    pub const ERROR_NOT_ENOUGH_AFTER_OUTLIER: u8 = 6;
-    pub const ERROR_POSITION_PROHIBITED: u8 = 7;
-    pub const ERROR_NOT_ENOUGH_DIFF_CORR: u8 = 8;
-    pub const ERROR_BASE_COORDS_UNAVAILABLE: u8 = 9;
-    pub const ERROR_AMBIGUITIES_NOT_FIXED: u8 = 10;
+    /// Mode flags (bits 6-7 of mode).
+    pub fn mode_flags(&self) -> PvtModeFlags {
+        PvtModeFlags::from_bits_truncate(self.mode_raw)
+    }
+
+    /// PVT error code.
+    pub fn error(&self) -> PvtError {
+        PvtError::from(self.error_raw)
+    }
 }

--- a/src/messages/vel_sensor_setup.rs
+++ b/src/messages/vel_sensor_setup.rs
@@ -20,32 +20,3 @@ pub struct VelSensorSetup {
     #[br(parse_with = binrw::helpers::until_eof)]
     pub padding: Vec<u8>,
 }
-
-impl VelSensorSetup {
-    // Port constants
-    pub const PORT_COM1: u8 = 0;
-    pub const PORT_COM2: u8 = 1;
-    pub const PORT_COM3: u8 = 2;
-    pub const PORT_COM4: u8 = 3;
-    pub const PORT_USB1: u8 = 5;
-    pub const PORT_USB2: u8 = 6;
-    pub const PORT_IP10: u8 = 7;
-    pub const PORT_IP11: u8 = 8;
-    pub const PORT_IP12: u8 = 9;
-    pub const PORT_IP13: u8 = 10;
-    pub const PORT_IP14: u8 = 11;
-    pub const PORT_IP15: u8 = 12;
-    pub const PORT_IP16: u8 = 13;
-    pub const PORT_IP17: u8 = 14;
-    pub const PORT_IPS1: u8 = 15;
-    pub const PORT_IPS2: u8 = 16;
-    pub const PORT_IPS3: u8 = 17;
-    pub const PORT_IPS4: u8 = 18;
-    pub const PORT_IPS5: u8 = 19;
-    pub const PORT_IPR1: u8 = 20;
-    pub const PORT_IPR2: u8 = 21;
-    pub const PORT_IPR3: u8 = 22;
-    pub const PORT_IPR4: u8 = 23;
-    pub const PORT_IPR5: u8 = 24;
-    pub const PORT_INTERNAL_IMU: u8 = 32;
-}


### PR DESCRIPTION
Moves some common enums and constants into the main messages module.