### PR TITLE
chore: add more cartesian and event types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "binrw"
-version = "0.13.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173901312e9850391d4d7c1318c4e099fdc037d61870fca427429830efdb4e5f"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
 dependencies = [
  "array-init",
  "binrw_derive",
@@ -113,15 +113,15 @@ dependencies = [
 
 [[package]]
 name = "binrw_derive"
-version = "0.13.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb515fdd6f8d3a357c8e19b8ec59ef53880807864329b1cb1cba5c53bf76557e"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
 dependencies = [
  "either",
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -194,7 +194,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -412,9 +412,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "pin-project-lite"
@@ -638,17 +638,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -988,5 +977,5 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libsbf"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-binrw = "0.13.3"
+binrw = "0.15"
 bitflags = "2"
 crc16 = "0.4.0"
 heapless = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["sbf-parser-fuzz"] }
 [package]
 name = "libsbf"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 license = "MPL-2.0"
 description = "A no_std rust crate to parse Septentrio SBF Messages."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,20 +33,25 @@ const DO_NOT_USE_F8: f64 = -2e10;
 
 // Re-export all message types at crate level
 pub use messages::{
-    AGCState, AttCovEuler, AttEuler, AttitudeMode, AuxAntPositionSub, AuxAntPositions, BDSIon,
-    BaselineError, Commands, Datum, DiffCorrIn, DiffCorrType, EndOfMeas, ExtError, ExtSensorInfo,
-    ExtSensorMeas, ExtSensorMeasAcceleration, ExtSensorMeasAngularRate, ExtSensorMeasInfo,
-    ExtSensorMeasSet, ExtSensorMeasSetType, ExtSensorMeasVelocity, ExtSensorMeasZeroVelocityFlag,
-    ExtSensorStatus, GALGstGps, GALIon, GALNav, GALUtc, GEONav, GEORawL1, GPSCNav, GPSIon, GPSNav,
-    GPSUtc, GnssMode, INSCouplingMode, INSError, INSNavCart, INSNavCartAtt, INSNavCartAttCov,
-    INSNavCartAttStdDev, INSNavCartPosCov, INSNavCartPosStdDev, INSNavCartVel, INSNavCartVelCov,
-    INSNavCartVelStdDev, INSNavGeod, INSNavGeodAtt, INSNavGeodAttCov, INSNavGeodAttStdDev,
-    INSNavGeodPosCov, INSNavGeodPosStdDev, INSNavGeodVel, INSNavGeodVelCov, INSNavGeodVelStdDev,
-    INSSolutionLocation, INSSupport, ImuSetup, Meas3Doppler, Meas3Ranges, MeasEpoch,
-    MeasEpochChannelType1, MeasEpochChannelType2, MeasExtra, MeasExtraChannelSub, NavCart, PVTCartesian,
-    PVTGeodetic, PosCovCartesian, PosCovGeodetic, PvtError, PvtMode, PvtModeFlags, QualityInd,
-    QualityIndicator, RFBand, RFStatus, RaimIntegrity, ReceiverSetup, ReceiverStatus, RxError,
-    RxState, VelCovCartesian, VelSensorSetup, WACorrFlags,
+    AGCState, AttCovEuler, AttEuler, AttitudeMode, AuxAntPositionSub, AuxAntPositions,
+    BaseVectorCart, BaselineError, BDSIon, Commands, Datum, DiffCorrIn, DiffCorrType, EndOfMeas,
+    EventPolarity, EventSource, ExtError, ExtEvent, ExtEventINSNavCart, ExtEventINSNavCartAtt,
+    ExtEventINSNavCartAttStdDev, ExtEventINSNavCartPosStdDev, ExtEventINSNavCartVel,
+    ExtEventINSNavCartVelStdDev, ExtEventINSNavGeod, ExtEventINSNavGeodAtt,
+    ExtEventINSNavGeodAttStdDev, ExtEventINSNavGeodPosStdDev, ExtEventINSNavGeodVel,
+    ExtEventINSNavGeodVelStdDev, ExtSensorInfo, ExtSensorMeas, ExtSensorMeasAcceleration,
+    ExtSensorMeasAngularRate, ExtSensorMeasInfo, ExtSensorMeasSet, ExtSensorMeasSetType,
+    ExtSensorMeasVelocity, ExtSensorMeasZeroVelocityFlag, ExtSensorStatus, GALGstGps, GALIon,
+    GALNav, GALUtc, GEONav, GEORawL1, GPSCNav, GPSIon, GPSNav, GPSUtc, GnssMode, INSCouplingMode,
+    INSError, INSNavCart, INSNavCartAtt, INSNavCartAttCov, INSNavCartAttStdDev, INSNavCartPosCov,
+    INSNavCartPosStdDev, INSNavCartVel, INSNavCartVelCov, INSNavCartVelStdDev, INSNavGeod,
+    INSNavGeodAtt, INSNavGeodAttCov, INSNavGeodAttStdDev, INSNavGeodPosCov, INSNavGeodPosStdDev,
+    INSNavGeodVel, INSNavGeodVelCov, INSNavGeodVelStdDev, INSSolutionLocation, INSSupport,
+    ImuSetup, Meas3Doppler, Meas3Ranges, MeasEpoch, MeasEpochChannelType1, MeasEpochChannelType2,
+    MeasExtra, MeasExtraChannelSub, NavCart, PVTCartesian, PVTGeodetic, PosCart, PosCovCartesian,
+    PosCovGeodetic, PvtError, PvtMode, PvtModeFlags, QualityInd, QualityIndicator, RFBand,
+    RFStatus, RaimIntegrity, ReceiverSetup, ReceiverStatus, RxError, RxState, VectorInfoCart,
+    VelCovCartesian, VelSensorSetup, WACorrFlags,
 };
 
 // Re-export datagram parser
@@ -124,6 +129,8 @@ define_messages!(
     GALIon => 4030,
     GALUtc => 4031,
     GALGstGps => 4032,
+    BaseVectorCart => 4043,
+    PosCart => 4044,
     GPSCNav => 4042,
     INSSupport => 4077,
     Meas3Ranges => 4109,
@@ -133,6 +140,8 @@ define_messages!(
     ExtSensorStatus => 4223,
     INSNavCart => 4225,
     INSNavGeod => 4226,
+    ExtEventINSNavCart => 4229,
+    ExtEventINSNavGeod => 4230,
     VelSensorSetup => 4244,
     AttEuler => 5938,
     AttCovEuler => 5939,
@@ -152,6 +161,7 @@ define_messages!(
     PosCovGeodetic => 5906,
     VelCovCartesian => 5907,
     EndOfMeas => 5922,
+    ExtEvent => 5924,
 );
 
 pub fn is_sync(bytes: &[u8; 2]) -> bool {

--- a/src/messages/base_vector_cart.rs
+++ b/src/messages/base_vector_cart.rs
@@ -12,7 +12,7 @@ pub struct BaseVectorCart {
     pub wnc: Option<u16>,
     pub n: u8,
     pub sb_length: u8,
-    #[br(count = n)]
+    #[br(count = usize::from(n))]
     pub vectors: Vec<VectorInfoCart>,
 }
 

--- a/src/messages/base_vector_cart.rs
+++ b/src/messages/base_vector_cart.rs
@@ -1,0 +1,71 @@
+use alloc::vec::Vec;
+use binrw::BinRead;
+
+use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
+
+// BaseVectorCart Block 4043
+#[derive(Debug, BinRead)]
+pub struct BaseVectorCart {
+    #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    pub n: u8,
+    pub sb_length: u8,
+    #[br(count = n)]
+    pub vectors: Vec<VectorInfoCart>,
+}
+
+// VectorInfoCart sub-block
+#[derive(Debug, BinRead)]
+pub struct VectorInfoCart {
+    #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(x) })]
+    pub nr_sv: Option<u8>,
+    #[br(map = |x: u8| PvtError::from(x))]
+    pub error: PvtError,
+    mode_raw: u8,
+    pub misc: u8,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub delta_x: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub delta_y: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub delta_z: Option<f64>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub delta_vx: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub delta_vy: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub delta_vz: Option<f32>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub azimuth: Option<u16>,
+    #[br(map = |x: i16| if x == crate::DO_NOT_USE_I2 { None } else { Some(x) })]
+    pub elevation: Option<i16>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub reference_id: Option<u16>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub corr_age: Option<u16>,
+    pub signal_info: u32,
+}
+
+impl VectorInfoCart {
+    /// PVT mode (bits 0-3 of mode).
+    pub fn pvt_mode(&self) -> PvtMode {
+        PvtMode::from(self.mode_raw)
+    }
+
+    /// Mode flags (bits 6-7 of mode).
+    pub fn mode_flags(&self) -> PvtModeFlags {
+        PvtModeFlags::from_bits_truncate(self.mode_raw)
+    }
+
+    /// Bit 0: Baseline points to base station ARP.
+    pub fn baseline_points_to_arp(&self) -> bool {
+        self.misc & 1 != 0
+    }
+
+    /// Bit 1: Phase center offset compensated at rover.
+    pub fn phase_center_compensated(&self) -> bool {
+        self.misc & (1 << 1) != 0
+    }
+}

--- a/src/messages/ext_event.rs
+++ b/src/messages/ext_event.rs
@@ -1,0 +1,70 @@
+use alloc::vec::Vec;
+use binrw::BinRead;
+
+// ExtEvent Block 5924
+#[derive(Debug, BinRead)]
+pub struct ExtEvent {
+    #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    pub source: u8,
+    pub polarity: u8,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub offset: Option<f32>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub rx_clk_bias: Option<f64>,
+    // Rev 1
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub pvt_age: Option<u16>,
+    #[br(parse_with = binrw::helpers::until_eof)]
+    pub padding: Vec<u8>,
+}
+
+/// Event input pin source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventSource {
+    EventA,
+    EventB,
+    Unknown(u8),
+}
+
+impl From<u8> for EventSource {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => EventSource::EventA,
+            2 => EventSource::EventB,
+            x => EventSource::Unknown(x),
+        }
+    }
+}
+
+/// Event polarity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventPolarity {
+    Rising,
+    Falling,
+    Unknown(u8),
+}
+
+impl From<u8> for EventPolarity {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => EventPolarity::Rising,
+            1 => EventPolarity::Falling,
+            x => EventPolarity::Unknown(x),
+        }
+    }
+}
+
+impl ExtEvent {
+    /// Event input pin.
+    pub fn event_source(&self) -> EventSource {
+        EventSource::from(self.source)
+    }
+
+    /// Event polarity (rising or falling edge).
+    pub fn event_polarity(&self) -> EventPolarity {
+        EventPolarity::from(self.polarity)
+    }
+}

--- a/src/messages/ext_event_ins_nav_cart.rs
+++ b/src/messages/ext_event_ins_nav_cart.rs
@@ -1,0 +1,142 @@
+use binrw::BinRead;
+
+use super::att_euler::AttitudeMode;
+use super::ins_nav_geod::{GnssMode, INSCouplingMode, INSError, INSSolutionLocation};
+use super::pvt_geodetic::{Datum, PvtMode};
+
+// ExtEventINSNavCart Block 4229
+// Same structure as INSNavCart, but at external event time.
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCart {
+    #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    gnss_mode_raw: u8,
+    pub error: u8,
+    pub info: u16,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub gnss_age: Option<u16>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub x: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub y: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub z: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub accuracy: Option<u16>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub latency: Option<u16>,
+    #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(Datum::from(x)) })]
+    pub datum: Option<Datum>,
+    _reserved: u8,
+    pub sb_list: u16,
+
+    #[br(if(sb_list & 1 == 1))]
+    pub pos_std_dev: Option<ExtEventINSNavCartPosStdDev>,
+    #[br(if((sb_list >> 1) & 1 == 1))]
+    pub att: Option<ExtEventINSNavCartAtt>,
+    #[br(if((sb_list >> 2) & 1 == 1))]
+    pub att_std_dev: Option<ExtEventINSNavCartAttStdDev>,
+    #[br(if((sb_list >> 3) & 1 == 1))]
+    pub vel: Option<ExtEventINSNavCartVel>,
+    #[br(if((sb_list >> 4) & 1 == 1))]
+    pub vel_std_dev: Option<ExtEventINSNavCartVelStdDev>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCartPosStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub x_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub y_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub z_std_dev: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCartAtt {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub heading: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub pitch: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub roll: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCartAttStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub heading_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub pitch_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub roll_std_dev: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCartVel {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vx: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vy: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vz: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavCartVelStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vx_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vy_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vz_std_dev: Option<f32>,
+}
+
+impl ExtEventINSNavCart {
+    /// Combined GNSS mode (PVT mode + attitude mode).
+    pub fn gnss_mode(&self) -> GnssMode {
+        GnssMode::from_byte(self.gnss_mode_raw)
+    }
+
+    /// Last GNSS PVT mode used by INS filter (bits 0-3 of gnss_mode).
+    pub fn pvt_mode(&self) -> PvtMode {
+        PvtMode::from(self.gnss_mode_raw & 0x0F)
+    }
+
+    /// Last GNSS Attitude mode used by INS filter (bits 4-7 of gnss_mode).
+    pub fn attitude_mode(&self) -> AttitudeMode {
+        AttitudeMode::from((self.gnss_mode_raw >> 4) as u16)
+    }
+
+    /// INS error code.
+    pub fn ins_error(&self) -> INSError {
+        INSError::from(self.error)
+    }
+
+    /// INS coupling mode (bits 0-2 of info).
+    pub fn coupling_mode(&self) -> INSCouplingMode {
+        INSCouplingMode::from(self.info)
+    }
+
+    /// Solution output location (bits 3-5 of info).
+    pub fn solution_location(&self) -> INSSolutionLocation {
+        INSSolutionLocation::from(self.info)
+    }
+
+    /// Bit 6: 180-degree heading ambiguity fixed.
+    pub fn heading_ambiguity_fixed(&self) -> bool {
+        self.info & (1 << 6) != 0
+    }
+
+    /// Bit 7: Zero-velocity constraints used.
+    pub fn zero_velocity_constraints(&self) -> bool {
+        self.info & (1 << 7) != 0
+    }
+
+    /// Bit 8: IMU orientation estimation has converged.
+    pub fn imu_orientation_converged(&self) -> bool {
+        self.info & (1 << 8) != 0
+    }
+}

--- a/src/messages/ext_event_ins_nav_geod.rs
+++ b/src/messages/ext_event_ins_nav_geod.rs
@@ -1,0 +1,144 @@
+use binrw::BinRead;
+
+use super::att_euler::AttitudeMode;
+use super::ins_nav_geod::{GnssMode, INSCouplingMode, INSError, INSSolutionLocation};
+use super::pvt_geodetic::{Datum, PvtMode};
+
+// ExtEventINSNavGeod Block 4230
+// Same structure as INSNavGeod, but at external event time.
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeod {
+    #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    gnss_mode_raw: u8,
+    pub error: u8,
+    pub info: u16,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub gnss_age: Option<u16>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub latitude: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub longitude: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub height: Option<f64>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub undulation: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub accuracy: Option<u16>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub latency: Option<u16>,
+    #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(Datum::from(x)) })]
+    pub datum: Option<Datum>,
+    _reserved: u8,
+    pub sb_list: u16,
+
+    #[br(if(sb_list & 1 == 1))]
+    pub pos_std_dev: Option<ExtEventINSNavGeodPosStdDev>,
+    #[br(if((sb_list >> 1) & 1 == 1))]
+    pub att: Option<ExtEventINSNavGeodAtt>,
+    #[br(if((sb_list >> 2) & 1 == 1))]
+    pub att_std_dev: Option<ExtEventINSNavGeodAttStdDev>,
+    #[br(if((sb_list >> 3) & 1 == 1))]
+    pub vel: Option<ExtEventINSNavGeodVel>,
+    #[br(if((sb_list >> 4) & 1 == 1))]
+    pub vel_std_dev: Option<ExtEventINSNavGeodVelStdDev>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeodPosStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub longitude_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub latitude_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub height_std_dev: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeodAtt {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub heading: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub pitch: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub roll: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeodAttStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub heading_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub pitch_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub roll_std_dev: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeodVel {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub ve: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vn: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vu: Option<f32>,
+}
+
+#[derive(Debug, BinRead)]
+pub struct ExtEventINSNavGeodVelStdDev {
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub ve_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vn_std_dev: Option<f32>,
+    #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub vu_std_dev: Option<f32>,
+}
+
+impl ExtEventINSNavGeod {
+    /// Combined GNSS mode (PVT mode + attitude mode).
+    pub fn gnss_mode(&self) -> GnssMode {
+        GnssMode::from_byte(self.gnss_mode_raw)
+    }
+
+    /// Last GNSS PVT mode used by INS filter (bits 0-3 of gnss_mode).
+    pub fn pvt_mode(&self) -> PvtMode {
+        PvtMode::from(self.gnss_mode_raw & 0x0F)
+    }
+
+    /// Last GNSS Attitude mode used by INS filter (bits 4-7 of gnss_mode).
+    pub fn attitude_mode(&self) -> AttitudeMode {
+        AttitudeMode::from((self.gnss_mode_raw >> 4) as u16)
+    }
+
+    /// INS error code.
+    pub fn ins_error(&self) -> INSError {
+        INSError::from(self.error)
+    }
+
+    /// INS coupling mode (bits 0-2 of info).
+    pub fn coupling_mode(&self) -> INSCouplingMode {
+        INSCouplingMode::from(self.info)
+    }
+
+    /// Solution output location (bits 3-5 of info).
+    pub fn solution_location(&self) -> INSSolutionLocation {
+        INSSolutionLocation::from(self.info)
+    }
+
+    /// Bit 6: 180-degree heading ambiguity fixed.
+    pub fn heading_ambiguity_fixed(&self) -> bool {
+        self.info & (1 << 6) != 0
+    }
+
+    /// Bit 7: Zero-velocity constraints used.
+    pub fn zero_velocity_constraints(&self) -> bool {
+        self.info & (1 << 7) != 0
+    }
+
+    /// Bit 8: IMU orientation estimation has converged.
+    pub fn imu_orientation_converged(&self) -> bool {
+        self.info & (1 << 8) != 0
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,10 +1,14 @@
 pub mod att_cov_euler;
 pub mod att_euler;
 pub mod aux_ant_positions;
+pub mod base_vector_cart;
 pub mod bds_ion;
 pub mod commands;
 pub mod diff_corr_in;
 pub mod end_of_meas;
+pub mod ext_event;
+pub mod ext_event_ins_nav_cart;
+pub mod ext_event_ins_nav_geod;
 pub mod ext_sensor_info;
 pub mod ext_sensor_meas;
 pub mod ext_sensor_status;
@@ -23,10 +27,11 @@ pub mod ins_nav_cart;
 pub mod ins_nav_geod;
 pub mod ins_support;
 pub mod meas3_doppler;
-pub mod nav_cart;
 pub mod meas3_ranges;
+pub mod nav_cart;
 pub mod meas_epoch;
 pub mod meas_extra;
+pub mod pos_cart;
 pub mod pos_cov_cartesian;
 pub mod pos_cov_geodetic;
 pub mod pvt_cartesian;
@@ -41,10 +46,20 @@ pub mod vel_sensor_setup;
 pub use att_cov_euler::AttCovEuler;
 pub use att_euler::{AttEuler, AttitudeMode, BaselineError};
 pub use aux_ant_positions::{AuxAntPositionSub, AuxAntPositions};
+pub use base_vector_cart::{BaseVectorCart, VectorInfoCart};
 pub use bds_ion::BDSIon;
 pub use commands::Commands;
 pub use diff_corr_in::DiffCorrIn;
 pub use end_of_meas::EndOfMeas;
+pub use ext_event::{EventPolarity, EventSource, ExtEvent};
+pub use ext_event_ins_nav_cart::{
+    ExtEventINSNavCart, ExtEventINSNavCartAtt, ExtEventINSNavCartAttStdDev,
+    ExtEventINSNavCartPosStdDev, ExtEventINSNavCartVel, ExtEventINSNavCartVelStdDev,
+};
+pub use ext_event_ins_nav_geod::{
+    ExtEventINSNavGeod, ExtEventINSNavGeodAtt, ExtEventINSNavGeodAttStdDev,
+    ExtEventINSNavGeodPosStdDev, ExtEventINSNavGeodVel, ExtEventINSNavGeodVelStdDev,
+};
 pub use ext_sensor_info::ExtSensorInfo;
 pub use ext_sensor_meas::{
     ExtSensorMeas, ExtSensorMeasAcceleration, ExtSensorMeasAngularRate, ExtSensorMeasInfo,
@@ -77,6 +92,7 @@ pub use nav_cart::NavCart;
 pub use meas3_ranges::Meas3Ranges;
 pub use meas_epoch::{MeasEpoch, MeasEpochChannelType1, MeasEpochChannelType2};
 pub use meas_extra::{MeasExtra, MeasExtraChannelSub};
+pub use pos_cart::PosCart;
 pub use pos_cov_cartesian::PosCovCartesian;
 pub use pos_cov_geodetic::PosCovGeodetic;
 pub use pvt_cartesian::PVTCartesian;

--- a/src/messages/pos_cart.rs
+++ b/src/messages/pos_cart.rs
@@ -1,0 +1,100 @@
+use alloc::vec::Vec;
+use binrw::BinRead;
+
+use super::pvt_geodetic::{
+    Datum, DiffCorrType, PvtError, PvtMode, PvtModeFlags, RaimIntegrity, WACorrFlags,
+};
+
+// PosCart Block 4044
+#[derive(Debug, BinRead)]
+pub struct PosCart {
+    #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    mode_raw: u8,
+    #[br(map = |x: u8| PvtError::from(x))]
+    pub error: PvtError,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub x: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub y: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub z: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub base2rover_x: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub base2rover_y: Option<f64>,
+    #[br(map = |x: f64| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
+    pub base2rover_z: Option<f64>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_xx: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_yy: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_zz: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_xy: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_xz: Option<f32>,
+    #[br(map = |x: f32| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
+    pub cov_yz: Option<f32>,
+    #[br(map = |x: u16| if x == 0 { None } else { Some(x) })]
+    pub pdop: Option<u16>,
+    #[br(map = |x: u16| if x == 0 { None } else { Some(x) })]
+    pub hdop: Option<u16>,
+    #[br(map = |x: u16| if x == 0 { None } else { Some(x) })]
+    pub vdop: Option<u16>,
+    pub misc: u8,
+    _reserved: u8,
+    alert_flag_raw: u8,
+    #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(Datum::from(x)) })]
+    pub datum: Option<Datum>,
+    #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(x) })]
+    pub nr_sv: Option<u8>,
+    wa_corr_info_raw: u8,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub reference_id: Option<u16>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub mean_corr_age: Option<u16>,
+    pub signal_info: u32,
+    #[br(parse_with = binrw::helpers::until_eof)]
+    pub padding: Vec<u8>,
+}
+
+impl PosCart {
+    /// PVT mode (bits 0-3 of mode).
+    pub fn pvt_mode(&self) -> PvtMode {
+        PvtMode::from(self.mode_raw)
+    }
+
+    /// Mode flags (bits 6-7 of mode).
+    pub fn mode_flags(&self) -> PvtModeFlags {
+        PvtModeFlags::from_bits_truncate(self.mode_raw)
+    }
+
+    /// Wide Area correction flags (bits 0-4).
+    pub fn wa_corr_flags(&self) -> WACorrFlags {
+        WACorrFlags::from_bits_truncate(self.wa_corr_info_raw)
+    }
+
+    /// Differential correction type (bits 5-6).
+    pub fn diff_corr_type(&self) -> DiffCorrType {
+        DiffCorrType::from(self.wa_corr_info_raw)
+    }
+
+    /// RAIM integrity status (bits 0-1 of alert_flag).
+    pub fn raim_integrity(&self) -> RaimIntegrity {
+        RaimIntegrity::from(self.alert_flag_raw)
+    }
+
+    /// Bit 2: Galileo HPCA integrity failed.
+    pub fn galileo_hpca_failed(&self) -> bool {
+        self.alert_flag_raw & (1 << 2) != 0
+    }
+
+    /// Bit 3: Galileo ionospheric storm active.
+    pub fn galileo_iono_storm(&self) -> bool {
+        self.alert_flag_raw & (1 << 3) != 0
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,11 +5,12 @@ use binrw::io::Cursor;
 use binrw::BinRead;
 
 use crate::{
-    AttCovEuler, AttEuler, AuxAntPositions, BDSIon, Commands, DiffCorrIn, EndOfMeas, ExtSensorInfo,
-    ExtSensorMeas, ExtSensorStatus, GALGstGps, GALIon, GALNav, GALUtc, GEONav, GEORawL1, GPSCNav,
-    GPSIon, GPSNav, GPSUtc, Header, INSNavCart, INSNavGeod, INSSupport, ImuSetup, Meas3Doppler,
+    AttCovEuler, AttEuler, AuxAntPositions, BaseVectorCart, BDSIon, Commands, DiffCorrIn,
+    EndOfMeas, ExtEvent, ExtEventINSNavCart, ExtEventINSNavGeod, ExtSensorInfo, ExtSensorMeas,
+    ExtSensorStatus, GALGstGps, GALIon, GALNav, GALUtc, GEONav, GEORawL1, GPSCNav, GPSIon,
+    GPSNav, GPSUtc, Header, INSNavCart, INSNavGeod, INSSupport, ImuSetup, Meas3Doppler,
     Meas3Ranges, MeasEpoch, MeasExtra, MessageKind, Messages, NavCart, PVTCartesian, PVTGeodetic,
-    PosCovCartesian, PosCovGeodetic, QualityInd, RFStatus, ReceiverSetup, ReceiverStatus,
+    PosCart, PosCovCartesian, PosCovGeodetic, QualityInd, RFStatus, ReceiverSetup, ReceiverStatus,
     VelCovCartesian, VelSensorSetup,
 };
 
@@ -307,6 +308,18 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
                 GPSUtc::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
             Messages::GPSUtc(gps_utc)
         }
+        MessageKind::BaseVectorCart => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let base_vector_cart = BaseVectorCart::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::BaseVectorCart(base_vector_cart)
+        }
+        MessageKind::PosCart => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let pos_cart =
+                PosCart::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
+            Messages::PosCart(pos_cart)
+        }
         MessageKind::PVTCartesian => {
             let mut body_cursor = Cursor::new(payload.as_slice());
             let pvt_cartesian = PVTCartesian::read_le(&mut body_cursor)
@@ -318,6 +331,18 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
             let ins_nav_cart = INSNavCart::read_le(&mut body_cursor)
                 .map_err(|_| ParseError::InvalidPayload)?;
             Messages::INSNavCart(ins_nav_cart)
+        }
+        MessageKind::ExtEventINSNavCart => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let msg = ExtEventINSNavCart::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ExtEventINSNavCart(msg)
+        }
+        MessageKind::ExtEventINSNavGeod => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let msg = ExtEventINSNavGeod::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ExtEventINSNavGeod(msg)
         }
         MessageKind::AuxAntPositions => {
             let mut body_cursor = Cursor::new(payload.as_slice());
@@ -348,6 +373,12 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
             let end_of_meas = EndOfMeas::read_le(&mut body_cursor)
                 .map_err(|_| ParseError::InvalidPayload)?;
             Messages::EndOfMeas(end_of_meas)
+        }
+        MessageKind::ExtEvent => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let ext_event =
+                ExtEvent::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ExtEvent(ext_event)
         }
         MessageKind::Unsupported => {
             // This should never be reached because we reject unsupported blocks above
@@ -573,11 +604,23 @@ pub fn parse_datagram(datagram: &[u8]) -> core::result::Result<Messages, Datagra
         MessageKind::GPSUtc => Messages::GPSUtc(
             GPSUtc::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
+        MessageKind::BaseVectorCart => Messages::BaseVectorCart(
+            BaseVectorCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::PosCart => Messages::PosCart(
+            PosCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
         MessageKind::PVTCartesian => Messages::PVTCartesian(
             PVTCartesian::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
         MessageKind::INSNavCart => Messages::INSNavCart(
             INSNavCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::ExtEventINSNavCart => Messages::ExtEventINSNavCart(
+            ExtEventINSNavCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::ExtEventINSNavGeod => Messages::ExtEventINSNavGeod(
+            ExtEventINSNavGeod::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
         MessageKind::AuxAntPositions => Messages::AuxAntPositions(
             AuxAntPositions::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
@@ -593,6 +636,9 @@ pub fn parse_datagram(datagram: &[u8]) -> core::result::Result<Messages, Datagra
         ),
         MessageKind::EndOfMeas => Messages::EndOfMeas(
             EndOfMeas::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::ExtEvent => Messages::ExtEvent(
+            ExtEvent::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
         MessageKind::Unsupported => unreachable!(),
     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -230,6 +230,18 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
                 INSNavGeod::read_le(&mut body_cursor).map_err(|_| ParseError::InvalidPayload)?;
             Messages::INSNavGeod(ins_nav_geod)
         }
+        MessageKind::ExtEventINSNavCart => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let msg = ExtEventINSNavCart::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ExtEventINSNavCart(msg)
+        }
+        MessageKind::ExtEventINSNavGeod => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let msg = ExtEventINSNavGeod::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::ExtEventINSNavGeod(msg)
+        }
         MessageKind::VelSensorSetup => {
             let mut body_cursor = Cursor::new(payload.as_slice());
             let vel_sensor_setup = VelSensorSetup::read_le(&mut body_cursor)
@@ -331,18 +343,6 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
             let ins_nav_cart = INSNavCart::read_le(&mut body_cursor)
                 .map_err(|_| ParseError::InvalidPayload)?;
             Messages::INSNavCart(ins_nav_cart)
-        }
-        MessageKind::ExtEventINSNavCart => {
-            let mut body_cursor = Cursor::new(payload.as_slice());
-            let msg = ExtEventINSNavCart::read_le(&mut body_cursor)
-                .map_err(|_| ParseError::InvalidPayload)?;
-            Messages::ExtEventINSNavCart(msg)
-        }
-        MessageKind::ExtEventINSNavGeod => {
-            let mut body_cursor = Cursor::new(payload.as_slice());
-            let msg = ExtEventINSNavGeod::read_le(&mut body_cursor)
-                .map_err(|_| ParseError::InvalidPayload)?;
-            Messages::ExtEventINSNavGeod(msg)
         }
         MessageKind::AuxAntPositions => {
             let mut body_cursor = Cursor::new(payload.as_slice());
@@ -565,6 +565,12 @@ pub fn parse_datagram(datagram: &[u8]) -> core::result::Result<Messages, Datagra
         MessageKind::INSNavGeod => Messages::INSNavGeod(
             INSNavGeod::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
+        MessageKind::ExtEventINSNavCart => Messages::ExtEventINSNavCart(
+            ExtEventINSNavCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::ExtEventINSNavGeod => Messages::ExtEventINSNavGeod(
+            ExtEventINSNavGeod::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
         MessageKind::VelSensorSetup => Messages::VelSensorSetup(
             VelSensorSetup::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
@@ -615,12 +621,6 @@ pub fn parse_datagram(datagram: &[u8]) -> core::result::Result<Messages, Datagra
         ),
         MessageKind::INSNavCart => Messages::INSNavCart(
             INSNavCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
-        ),
-        MessageKind::ExtEventINSNavCart => Messages::ExtEventINSNavCart(
-            ExtEventINSNavCart::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
-        ),
-        MessageKind::ExtEventINSNavGeod => Messages::ExtEventINSNavGeod(
-            ExtEventINSNavGeod::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
         MessageKind::AuxAntPositions => Messages::AuxAntPositions(
             AuxAntPositions::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,


### PR DESCRIPTION
Adds the following types:
- PosCart — Absolute position + baseline + covariance + DOP in Cartesian
- BaseVectorCart — Multi-base baseline vectors with variable VectorInfoCart sub-blocks
- ExtEvent — External event time tag with EventSource/EventPolarity enums
- ExtEventINSNavCart — Same structure as INSNavCart but at external event time
- ExtEventINSNavGeod — Same structure as INSNavGeod but at external event time