### PR TITLE
Support for "EndOfMeas" blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ const DO_NOT_USE_F8: f64 = -2e10;
 // Re-export all message types at crate level
 pub use messages::{
     AGCState, AttCovEuler, AttEuler, AttitudeMode, AuxAntPositionSub, AuxAntPositions, BDSIon,
-    BaselineError, Commands, Datum, DiffCorrIn, DiffCorrType, ExtError, ExtSensorInfo,
+    BaselineError, Commands, Datum, DiffCorrIn, DiffCorrType, EndOfMeas, ExtError, ExtSensorInfo,
     ExtSensorMeas, ExtSensorMeasAcceleration, ExtSensorMeasAngularRate, ExtSensorMeasInfo,
     ExtSensorMeasSet, ExtSensorMeasSetType, ExtSensorMeasVelocity, ExtSensorMeasZeroVelocityFlag,
     ExtSensorStatus, GALGstGps, GALIon, GALNav, GALUtc, GEONav, GEORawL1, GPSCNav, GPSIon, GPSNav,
@@ -151,6 +151,7 @@ define_messages!(
     PosCovCartesian => 5905,
     PosCovGeodetic => 5906,
     VelCovCartesian => 5907,
+    EndOfMeas => 5922,
 );
 
 pub fn is_sync(bytes: &[u8; 2]) -> bool {

--- a/src/mega_test.rs
+++ b/src/mega_test.rs
@@ -47,6 +47,7 @@ mod tests {
             "BDSIon",
             "Commands",
             "DiffCorrIn",
+            "EndOfMeas",
             "ExtSensorInfo",
             "ExtSensorMeas",
             "ExtSensorStatus",
@@ -76,7 +77,7 @@ mod tests {
         ];
 
         // Check that we have at least 27 different message types
-        // (INSNavGeod might be missing if the file wasn't updated)
+        // (INSNavGeod and EndOfMeas might be missing if the file wasn't updated)
         let unique_types = message_counts.len();
         assert!(
             unique_types >= 27,

--- a/src/messages/end_of_meas.rs
+++ b/src/messages/end_of_meas.rs
@@ -1,0 +1,14 @@
+use alloc::vec::Vec;
+use binrw::binrw;
+
+// EndOfMeas Block 5922
+#[binrw]
+#[derive(Debug)]
+pub struct EndOfMeas {
+    #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
+    pub tow: Option<u32>,
+    #[br(map = |x: u16| if x == crate::DO_NOT_USE_U2 { None } else { Some(x) })]
+    pub wnc: Option<u16>,
+    #[br(parse_with = binrw::helpers::until_eof)]
+    pub padding: Vec<u8>,
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -4,6 +4,7 @@ pub mod aux_ant_positions;
 pub mod bds_ion;
 pub mod commands;
 pub mod diff_corr_in;
+pub mod end_of_meas;
 pub mod ext_sensor_info;
 pub mod ext_sensor_meas;
 pub mod ext_sensor_status;
@@ -43,6 +44,7 @@ pub use aux_ant_positions::{AuxAntPositionSub, AuxAntPositions};
 pub use bds_ion::BDSIon;
 pub use commands::Commands;
 pub use diff_corr_in::DiffCorrIn;
+pub use end_of_meas::EndOfMeas;
 pub use ext_sensor_info::ExtSensorInfo;
 pub use ext_sensor_meas::{
     ExtSensorMeas, ExtSensorMeasAcceleration, ExtSensorMeasAngularRate, ExtSensorMeasInfo,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use binrw::io::Cursor;
 use binrw::BinRead;
 
 use crate::{
-    AttCovEuler, AttEuler, AuxAntPositions, BDSIon, Commands, DiffCorrIn, ExtSensorInfo,
+    AttCovEuler, AttEuler, AuxAntPositions, BDSIon, Commands, DiffCorrIn, EndOfMeas, ExtSensorInfo,
     ExtSensorMeas, ExtSensorStatus, GALGstGps, GALIon, GALNav, GALUtc, GEONav, GEORawL1, GPSCNav,
     GPSIon, GPSNav, GPSUtc, Header, INSNavCart, INSNavGeod, INSSupport, ImuSetup, Meas3Doppler,
     Meas3Ranges, MeasEpoch, MeasExtra, MessageKind, Messages, NavCart, PVTCartesian, PVTGeodetic,
@@ -343,6 +343,12 @@ fn parse_message(input: &[u8]) -> Result<Messages> {
                 .map_err(|_| ParseError::InvalidPayload)?;
             Messages::VelCovCartesian(vel_cov_cart)
         }
+        MessageKind::EndOfMeas => {
+            let mut body_cursor = Cursor::new(payload.as_slice());
+            let end_of_meas = EndOfMeas::read_le(&mut body_cursor)
+                .map_err(|_| ParseError::InvalidPayload)?;
+            Messages::EndOfMeas(end_of_meas)
+        }
         MessageKind::Unsupported => {
             // This should never be reached because we reject unsupported blocks above
             unreachable!("Unsupported block should have been rejected earlier")
@@ -584,6 +590,9 @@ pub fn parse_datagram(datagram: &[u8]) -> core::result::Result<Messages, Datagra
         ),
         MessageKind::VelCovCartesian => Messages::VelCovCartesian(
             VelCovCartesian::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
+        ),
+        MessageKind::EndOfMeas => Messages::EndOfMeas(
+            EndOfMeas::read_le(&mut cursor).map_err(|_| DatagramError::InvalidPayload)?,
         ),
         MessageKind::Unsupported => unreachable!(),
     };


### PR DESCRIPTION
This PR adds support for the "EndOfMeas" block. This block marks the end of the transmission of all measurement-related blocks belonging to a given epoch.