### PR TITLE
timing, name information, and Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! define_messages {
         }
 
         /// Detailed enum that holds the associated payload.
-        #[derive(Debug)]
+        #[derive(Clone, Debug)]
         pub enum Messages {
             $( $variant($variant), )+
             Unsupported(u16),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,29 @@ macro_rules! define_messages {
             $( $variant($variant), )+
             Unsupported(u16),
         }
+
+        impl Messages {
+            pub fn type_name(&self) -> &'static str {
+                match self {
+                    $( Messages::$variant(_) => stringify!($variant), )+
+                    Messages::Unsupported(_) => "Unsupported",
+                }
+            }
+
+            pub fn tow(&self) -> Option<u32> {
+                match self {
+                    $( Messages::$variant(m) => m.tow, )+
+                    Messages::Unsupported(_) => None,
+                }
+            }
+
+            pub fn wnc(&self) -> Option<u16> {
+                match self {
+                    $( Messages::$variant(m) => m.wnc, )+
+                    Messages::Unsupported(_) => None,
+                }
+            }
+        }
     };
 }
 

--- a/src/messages/att_cov_euler.rs
+++ b/src/messages/att_cov_euler.rs
@@ -4,7 +4,7 @@ use super::att_euler::BaselineError;
 
 // AttCovEuler Block 5939
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AttCovEuler {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/att_euler.rs
+++ b/src/messages/att_euler.rs
@@ -67,7 +67,7 @@ impl From<u8> for BaselineError {
 
 // Attitude Euler Block 5938
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AttEuler {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/aux_ant_positions.rs
+++ b/src/messages/aux_ant_positions.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use binrw::BinRead;
 
 /// Sub-block for a single auxiliary antenna position.
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct AuxAntPositionSub {
     #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(x) })]
     pub nr_sv: Option<u8>,
@@ -25,7 +25,7 @@ pub struct AuxAntPositionSub {
 }
 
 // AuxAntPositions Block 5942
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct AuxAntPositions {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/base_vector_cart.rs
+++ b/src/messages/base_vector_cart.rs
@@ -4,7 +4,7 @@ use binrw::BinRead;
 use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
 
 // BaseVectorCart Block 4043
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct BaseVectorCart {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -17,7 +17,7 @@ pub struct BaseVectorCart {
 }
 
 // VectorInfoCart sub-block
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct VectorInfoCart {
     #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(x) })]
     pub nr_sv: Option<u8>,

--- a/src/messages/bds_ion.rs
+++ b/src/messages/bds_ion.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // BDSIon Block 4120
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BDSIon {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/commands.rs
+++ b/src/messages/commands.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // Commands Block 4015
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Commands {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/diff_corr_in.rs
+++ b/src/messages/diff_corr_in.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // DiffCorrIn Block 5919
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DiffCorrIn {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/dop.rs
+++ b/src/messages/dop.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 
 // DOP Block 4001
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DOP {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/end_of_meas.rs
+++ b/src/messages/end_of_meas.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // EndOfMeas Block 5922
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct EndOfMeas {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/ext_event.rs
+++ b/src/messages/ext_event.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use binrw::BinRead;
 
 // ExtEvent Block 5924
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEvent {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/ext_event_ins_nav_cart.rs
+++ b/src/messages/ext_event_ins_nav_cart.rs
@@ -6,7 +6,7 @@ use super::pvt_geodetic::{Datum, PvtMode};
 
 // ExtEventINSNavCart Block 4229
 // Same structure as INSNavCart, but at external event time.
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCart {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -44,7 +44,7 @@ pub struct ExtEventINSNavCart {
     pub vel_std_dev: Option<ExtEventINSNavCartVelStdDev>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCartPosStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub x_std_dev: Option<f32>,
@@ -54,7 +54,7 @@ pub struct ExtEventINSNavCartPosStdDev {
     pub z_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCartAtt {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading: Option<f32>,
@@ -64,7 +64,7 @@ pub struct ExtEventINSNavCartAtt {
     pub roll: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCartAttStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_std_dev: Option<f32>,
@@ -74,7 +74,7 @@ pub struct ExtEventINSNavCartAttStdDev {
     pub roll_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCartVel {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx: Option<f32>,
@@ -84,7 +84,7 @@ pub struct ExtEventINSNavCartVel {
     pub vz: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavCartVelStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx_std_dev: Option<f32>,

--- a/src/messages/ext_event_ins_nav_geod.rs
+++ b/src/messages/ext_event_ins_nav_geod.rs
@@ -6,7 +6,7 @@ use super::pvt_geodetic::{Datum, PvtMode};
 
 // ExtEventINSNavGeod Block 4230
 // Same structure as INSNavGeod, but at external event time.
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeod {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -46,7 +46,7 @@ pub struct ExtEventINSNavGeod {
     pub vel_std_dev: Option<ExtEventINSNavGeodVelStdDev>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeodPosStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub longitude_std_dev: Option<f32>,
@@ -56,7 +56,7 @@ pub struct ExtEventINSNavGeodPosStdDev {
     pub height_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeodAtt {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading: Option<f32>,
@@ -66,7 +66,7 @@ pub struct ExtEventINSNavGeodAtt {
     pub roll: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeodAttStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_std_dev: Option<f32>,
@@ -76,7 +76,7 @@ pub struct ExtEventINSNavGeodAttStdDev {
     pub roll_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeodVel {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub ve: Option<f32>,
@@ -86,7 +86,7 @@ pub struct ExtEventINSNavGeodVel {
     pub vu: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ExtEventINSNavGeodVelStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub ve_std_dev: Option<f32>,

--- a/src/messages/ext_sensor_info.rs
+++ b/src/messages/ext_sensor_info.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // ExtSensorInfo Block 4222
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorInfo {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/ext_sensor_meas.rs
+++ b/src/messages/ext_sensor_meas.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // External Sensor Measurement Block 4050
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeas {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -26,7 +26,7 @@ pub enum ExtSensorMeasSetType {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasSet {
     pub source: u8,
     pub sensor_model: u8,
@@ -46,7 +46,7 @@ pub struct ExtSensorMeasSet {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasAcceleration {
     #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
     pub ax: Option<f64>,
@@ -57,7 +57,7 @@ pub struct ExtSensorMeasAcceleration {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasAngularRate {
     #[br(map = |x| if x == crate::DO_NOT_USE_F8 { None } else { Some(x) })]
     pub wx: Option<f64>,
@@ -68,7 +68,7 @@ pub struct ExtSensorMeasAngularRate {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasVelocity {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx: Option<f32>,
@@ -85,7 +85,7 @@ pub struct ExtSensorMeasVelocity {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasInfo {
     #[br(map = |x| if x == crate::DO_NOT_USE_I2 { None } else { Some(x) })]
     pub sensor_temp: Option<i16>,
@@ -93,7 +93,7 @@ pub struct ExtSensorMeasInfo {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorMeasZeroVelocityFlag {
     pub zero_v_flag: f64,
     pub _reserved: [u8; 16],

--- a/src/messages/ext_sensor_status.rs
+++ b/src/messages/ext_sensor_status.rs
@@ -118,7 +118,7 @@ impl fmt::Display for ExtSensorModel {
 
 // ExtSensorStatus Block 4223
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExtSensorStatus {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gal_gst_gps.rs
+++ b/src/messages/gal_gst_gps.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GALGstGps Block 4032
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GALGstGps {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gal_ion.rs
+++ b/src/messages/gal_ion.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GALIon Block 4030
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GALIon {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gal_nav.rs
+++ b/src/messages/gal_nav.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GALNav Block 4002
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GALNav {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gal_utc.rs
+++ b/src/messages/gal_utc.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GALUtc Block 4031
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GALUtc {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/geo_nav.rs
+++ b/src/messages/geo_nav.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 
 // GEONav Block 5896
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GEONav {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/geo_raw_l1.rs
+++ b/src/messages/geo_raw_l1.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 
 // GEORawL1 Block 4020
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GEORawL1 {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gps_cnav.rs
+++ b/src/messages/gps_cnav.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GPSCNav Block 4042
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GPSCNav {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gps_ion.rs
+++ b/src/messages/gps_ion.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GPSIon Block 5893
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GPSIon {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gps_nav.rs
+++ b/src/messages/gps_nav.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GPSNav Block 5891
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GPSNav {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/gps_utc.rs
+++ b/src/messages/gps_utc.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // GPSUtc Block 5894
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GPSUtc {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/imu_setup.rs
+++ b/src/messages/imu_setup.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 
 // IMU Setup Block 4224
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ImuSetup {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/ins_nav_cart.rs
+++ b/src/messages/ins_nav_cart.rs
@@ -5,7 +5,7 @@ use super::ins_nav_geod::{GnssMode, INSCouplingMode, INSError, INSSolutionLocati
 use super::pvt_geodetic::{Datum, PvtMode};
 
 // INSNavCart Block 4225
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCart {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -51,7 +51,7 @@ pub struct INSNavCart {
     pub vel_cov: Option<INSNavCartVelCov>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartPosStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub x_std_dev: Option<f32>,
@@ -61,7 +61,7 @@ pub struct INSNavCartPosStdDev {
     pub z_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartAtt {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading: Option<f32>,
@@ -71,7 +71,7 @@ pub struct INSNavCartAtt {
     pub roll: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartAttStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_std_dev: Option<f32>,
@@ -81,7 +81,7 @@ pub struct INSNavCartAttStdDev {
     pub roll_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartVel {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx: Option<f32>,
@@ -91,7 +91,7 @@ pub struct INSNavCartVel {
     pub vz: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartVelStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx_std_dev: Option<f32>,
@@ -101,7 +101,7 @@ pub struct INSNavCartVelStdDev {
     pub vz_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartPosCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub xy_cov: Option<f32>,
@@ -111,7 +111,7 @@ pub struct INSNavCartPosCov {
     pub yz_cov: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartVelCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub vx_vy_cov: Option<f32>,
@@ -121,7 +121,7 @@ pub struct INSNavCartVelCov {
     pub vy_vz_cov: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavCartAttCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_pitch_cov: Option<f32>,

--- a/src/messages/ins_nav_geod.rs
+++ b/src/messages/ins_nav_geod.rs
@@ -126,7 +126,7 @@ impl Default for INSError {
 }
 
 // INS Nav Geod Block 4226
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeod {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -175,7 +175,7 @@ pub struct INSNavGeod {
     pub vel_cov: Option<INSNavGeodVelCov>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodPosStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub longitude_std_dev: Option<f32>,
@@ -185,7 +185,7 @@ pub struct INSNavGeodPosStdDev {
     pub height_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodAtt {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading: Option<f32>,
@@ -195,7 +195,7 @@ pub struct INSNavGeodAtt {
     pub roll: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodAttStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_std_dev: Option<f32>,
@@ -205,7 +205,7 @@ pub struct INSNavGeodAttStdDev {
     pub roll_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodVel {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub ve: Option<f32>,
@@ -215,7 +215,7 @@ pub struct INSNavGeodVel {
     pub vu: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodVelStdDev {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub ve_std_dev: Option<f32>,
@@ -225,7 +225,7 @@ pub struct INSNavGeodVelStdDev {
     pub vu_std_dev: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodPosCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub latitude_longitude_cov: Option<f32>,
@@ -235,7 +235,7 @@ pub struct INSNavGeodPosCov {
     pub longitude_height_cov: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodVelCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub ve_vn_cov: Option<f32>,
@@ -245,7 +245,7 @@ pub struct INSNavGeodVelCov {
     pub vn_vu_cov: Option<f32>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct INSNavGeodAttCov {
     #[br(map = |x| if x == crate::DO_NOT_USE_F4 { None } else { Some(x) })]
     pub heading_pitch_cov: Option<f32>,

--- a/src/messages/ins_support.rs
+++ b/src/messages/ins_support.rs
@@ -6,7 +6,7 @@ use binrw::binrw;
 // The documentation states that the reference C implementation should be used to
 // parse these messages. For now, we store the raw bytes.
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct INSSupport {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/meas3_doppler.rs
+++ b/src/messages/meas3_doppler.rs
@@ -6,7 +6,7 @@ use binrw::binrw;
 // The documentation states that the reference C implementation should be used to
 // parse these messages. For now, we store the raw bytes.
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Meas3Doppler {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/meas3_ranges.rs
+++ b/src/messages/meas3_ranges.rs
@@ -6,7 +6,7 @@ use binrw::binrw;
 // The documentation states that the reference C implementation should be used to
 // parse these messages. For now, we store the raw bytes.
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Meas3Ranges {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/meas_epoch.rs
+++ b/src/messages/meas_epoch.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // MeasEpoch Block 4027
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MeasEpoch {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -20,7 +20,7 @@ pub struct MeasEpoch {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MeasEpochChannelType1 {
     pub rx_channel: u8,
     pub type_field: u8,
@@ -43,7 +43,7 @@ pub struct MeasEpochChannelType1 {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MeasEpochChannelType2 {
     pub type_field: u8,
     #[br(map = |x: u8| if x == crate::DO_NOT_USE_U1 { None } else { Some(x) })]

--- a/src/messages/meas_extra.rs
+++ b/src/messages/meas_extra.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // MeasExtra Block 4000
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MeasExtra {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -17,7 +17,7 @@ pub struct MeasExtra {
 }
 
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MeasExtraChannelSub {
     pub rx_channel: u8,
     pub type_field: u8,

--- a/src/messages/nav_cart.rs
+++ b/src/messages/nav_cart.rs
@@ -8,7 +8,7 @@ use super::pvt_geodetic::{
 
 // NavCart Block 4272
 // Combined PVTCartesian + AttEuler + DOP + ReceiverTime fields.
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct NavCart {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/pos_cart.rs
+++ b/src/messages/pos_cart.rs
@@ -6,7 +6,7 @@ use super::pvt_geodetic::{
 };
 
 // PosCart Block 4044
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct PosCart {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/pos_cov_cartesian.rs
+++ b/src/messages/pos_cov_cartesian.rs
@@ -4,7 +4,7 @@ use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
 
 // PosCovCartesian Block 5905
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PosCovCartesian {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/pos_cov_geodetic.rs
+++ b/src/messages/pos_cov_geodetic.rs
@@ -4,7 +4,7 @@ use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
 
 // PosCovGeodetic Block 5906
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PosCovGeodetic {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/pvt_cartesian.rs
+++ b/src/messages/pvt_cartesian.rs
@@ -6,7 +6,7 @@ use super::pvt_geodetic::{
 };
 
 // PVTCartesian Block 4006
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct PVTCartesian {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/pvt_geodetic.rs
+++ b/src/messages/pvt_geodetic.rs
@@ -196,7 +196,7 @@ impl From<u8> for RaimIntegrity {
 }
 
 // PVTGeodetic Block 4007
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct PVTGeodetic {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/quality_ind.rs
+++ b/src/messages/quality_ind.rs
@@ -37,7 +37,7 @@ impl From<u16> for QualityIndicator {
 }
 
 // Quality Indicator Block 4082
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct QualityInd {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/receiver_setup.rs
+++ b/src/messages/receiver_setup.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 
 // Receiver Setup Block 5902
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ReceiverSetup {
     #[br(map = |x| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/receiver_status.rs
+++ b/src/messages/receiver_status.rs
@@ -50,7 +50,7 @@ bitflags! {
 }
 
 // ReceiverStatus Block 4014
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct ReceiverStatus {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,
@@ -75,7 +75,7 @@ pub struct ReceiverStatus {
     pub padding: Vec<u8>,
 }
 
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct AGCState {
     pub frontend_id: u8,
     #[br(map = |x: i8| if x == -128 { None } else { Some(x) })]

--- a/src/messages/rf_status.rs
+++ b/src/messages/rf_status.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use binrw::BinRead;
 
 /// RFBand sub-block: interference info for a single RF band.
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct RFBand {
     /// Center frequency of the RF band (Hz).
     pub frequency: u32,
@@ -39,7 +39,7 @@ impl RFBand {
 }
 
 // RFStatus Block 4092
-#[derive(Debug, BinRead)]
+#[derive(Clone, Debug, BinRead)]
 pub struct RFStatus {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/vel_cov_cartesian.rs
+++ b/src/messages/vel_cov_cartesian.rs
@@ -4,7 +4,7 @@ use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
 
 // VelCovCartesian Block 5907
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VelCovCartesian {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/vel_cov_geodetic.rs
+++ b/src/messages/vel_cov_geodetic.rs
@@ -4,7 +4,7 @@ use super::pvt_geodetic::{PvtError, PvtMode, PvtModeFlags};
 
 // VelCovGeodetic Block 5908
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VelCovGeodetic {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,

--- a/src/messages/vel_sensor_setup.rs
+++ b/src/messages/vel_sensor_setup.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 
 // VelSensorSetup Block 4244
 #[binrw]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VelSensorSetup {
     #[br(map = |x: u32| if x == crate::DO_NOT_USE_U4 { None } else { Some(x) })]
     pub tow: Option<u32>,


### PR DESCRIPTION
`tow`, `wnc` and `type_name` are really convenient to have for debugging tools (which I will not be adding here) since they apply to every message.

The `Clone` addition is for parity with `liban-rs`, and also reflected in #50. 