### PR TITLE
updated rust pins

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743993291,
-        "narHash": "sha256-u8GHvduU1gCtoFXvTS/wGjH1ouv5S/GRGq6MAT+sG/k=",
+        "lastModified": 1784091390,
+        "narHash": "sha256-aILAwrBQPhKldL98N8lmsbfst3OPtbMM4vT2VXn40/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0cb3c8979c65dc6a5812dfe67499a8c7b8b4325b",
+        "rev": "a7887636a3959168bd1ba7ef24a8a70b168dcb56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
         };
 
         rustPlatform = pkgs.makeRustPlatform {
-          cargo = pkgs.rust-bin.nightly.latest.default;
-          rustc = pkgs.rust-bin.nightly.latest.default;
+          cargo = pkgs.rust-bin.stable.latest.default;
+          rustc = pkgs.rust-bin.stable.latest.default;
         };
 
         cargo-afl = rustPlatform.buildRustPackage rec {
@@ -40,7 +40,7 @@
           nativeBuildInputs = [
             cargo-afl
             llvmPackages.libllvm
-            rust-bin.nightly.latest.default
+            rust-bin.stable.latest.default
             valgrind
           ];
         };


### PR DESCRIPTION
Rust version pinned in current flake will not build with `binrw`. We probably never noticed this because the broken `cargo afl` dependency would not let the default devshell run until #67 was fixed recently.

There is now a warning
```
warning: the following packages contain code that will be rejected by a future version of Rust: binrw v0.15.1
```
It is a known, well characterized issue that happened some time after `rustc` v1.95.0: https://github.com/jam1garner/binrw/issues/366, https://github.com/rust-lang/rust/issues/127909. It's been fixed upstream on `master`, just not released onto crates.io yet.