### PR TITLE
fixed invalid error flag conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libsbf"
-version = "0.15.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -341,6 +341,7 @@ dependencies = [
  "crc16",
  "heapless",
  "libsbf",
+ "num_enum",
  "proptest",
  "tracing",
  "tracing-subscriber",
@@ -390,6 +391,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -585,6 +607,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["sbf-parser-fuzz"] }
 [package]
 name = "libsbf"
-version = "0.15.5"
+version = "0.16.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A no_std rust crate to parse Septentrio SBF Messages."
@@ -16,6 +16,7 @@ binrw = "0.15"
 bitflags = "2"
 crc16 = "0.4.0"
 heapless = "0.8.0"
+num_enum = { version = "0.7", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 
 [dev-dependencies]

--- a/src/messages/ext_sensor_status.rs
+++ b/src/messages/ext_sensor_status.rs
@@ -1,15 +1,15 @@
 use alloc::vec::Vec;
 use binrw::binrw;
 use core::fmt;
+use num_enum::{FromPrimitive, IntoPrimitive};
 
 /// Connection port / external sensor source.
 ///
 /// Used by ExtSensorStatus, ExtSensorInfo, and VelSensorSetup to identify the
 /// receiver port an external sensor is connected to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum ConnectionPort {
-    #[default]
     Com1 = 0,
     Com2 = 1,
     Com3 = 2,
@@ -36,41 +36,8 @@ pub enum ConnectionPort {
     Ipr4 = 23,
     Ipr5 = 24,
     InternalSpi = 32,
-    Unknown,
-}
-
-impl From<u8> for ConnectionPort {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => ConnectionPort::Com1,
-            1 => ConnectionPort::Com2,
-            2 => ConnectionPort::Com3,
-            3 => ConnectionPort::Com4,
-            4 => ConnectionPort::Gpio,
-            5 => ConnectionPort::Usb1,
-            6 => ConnectionPort::Usb2,
-            7 => ConnectionPort::Ip10,
-            8 => ConnectionPort::Ip11,
-            9 => ConnectionPort::Ip12,
-            10 => ConnectionPort::Ip13,
-            11 => ConnectionPort::Ip14,
-            12 => ConnectionPort::Ip15,
-            13 => ConnectionPort::Ip16,
-            14 => ConnectionPort::Ip17,
-            15 => ConnectionPort::Ips1,
-            16 => ConnectionPort::Ips2,
-            17 => ConnectionPort::Ips3,
-            18 => ConnectionPort::Ips4,
-            19 => ConnectionPort::Ips5,
-            20 => ConnectionPort::Ipr1,
-            21 => ConnectionPort::Ipr2,
-            22 => ConnectionPort::Ipr3,
-            23 => ConnectionPort::Ipr4,
-            24 => ConnectionPort::Ipr5,
-            32 => ConnectionPort::InternalSpi,
-            _ => ConnectionPort::Unknown,
-        }
-    }
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
 impl fmt::Display for ConnectionPort {
@@ -102,7 +69,7 @@ impl fmt::Display for ConnectionPort {
             ConnectionPort::Ipr4 => write!(f, "IPR4"),
             ConnectionPort::Ipr5 => write!(f, "IPR5"),
             ConnectionPort::InternalSpi => write!(f, "Internal SPI"),
-            ConnectionPort::Unknown => write!(f, "Unknown"),
+            ConnectionPort::Unknown(x) => write!(f, "Unknown: {x}"),
         }
     }
 }

--- a/src/messages/ins_nav_geod.rs
+++ b/src/messages/ins_nav_geod.rs
@@ -1,10 +1,11 @@
 use binrw::BinRead;
 use core::fmt;
-use super::pvt_geodetic::{PvtMode, Datum};
+use num_enum::{FromPrimitive, IntoPrimitive};
 use super::att_euler::AttitudeMode;
+use super::pvt_geodetic::{Datum, PvtMode};
 
 /// Combined GNSS mode containing PVT mode (bits 0-3) and attitude mode (bits 4-7).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GnssMode {
     raw: u8,
     pub pvt_mode: PvtMode,
@@ -34,31 +35,45 @@ impl fmt::Display for GnssMode {
 }
 
 /// INS coupling mode (bits 0-2 of info field).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive)]
 #[repr(u8)]
 pub enum INSCouplingMode {
-    #[default]
     LooselyCoupled = 0,
-    Unknown,
+    #[num_enum(catch_all)]
+    Unknown(u8),
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for INSCouplingMode {
+    fn default() -> Self {
+        INSCouplingMode::LooselyCoupled
+    }
 }
 
 impl From<u16> for INSCouplingMode {
     fn from(value: u16) -> Self {
         match value & 0x07 {
             0 => INSCouplingMode::LooselyCoupled,
-            _ => INSCouplingMode::Unknown,
+            x => INSCouplingMode::Unknown(x as u8),
         }
     }
 }
 
 /// Solution output location (bits 3-5 of info field).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive)]
 #[repr(u8)]
 pub enum INSSolutionLocation {
-    #[default]
     MainGnssAntenna = 0,
     FirstPoi = 1,
-    Unknown,
+    #[num_enum(catch_all)]
+    Unknown(u8),
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for INSSolutionLocation {
+    fn default() -> Self {
+        INSSolutionLocation::MainGnssAntenna
+    }
 }
 
 impl From<u16> for INSSolutionLocation {
@@ -66,16 +81,15 @@ impl From<u16> for INSSolutionLocation {
         match (value >> 3) & 0x07 {
             0 => INSSolutionLocation::MainGnssAntenna,
             1 => INSSolutionLocation::FirstPoi,
-            _ => INSSolutionLocation::Unknown,
+            x => INSSolutionLocation::Unknown(x as u8),
         }
     }
 }
 
 /// INS error codes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum INSError {
-    #[default]
     None = 0,
     /// Position output prohibited due to export laws.
     PositionProhibited = 7,
@@ -99,25 +113,15 @@ pub enum INSError {
     UnsupportedSettings = 32,
     /// Incorrect IMU orientation.
     IncorrectImuOrientation = 35,
+    /// Unrecognized error code.
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
-impl From<u8> for INSError {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => INSError::None,
-            7 => INSError::PositionProhibited,
-            20 => INSError::NotRequested,
-            21 => INSError::NotEnoughSensorMeasurements,
-            23 => INSError::StaticAlignmentOngoing,
-            24 => INSError::WaitingForGnssPvt,
-            28 => INSError::InMotionAlignmentOngoing,
-            29 => INSError::WaitingForGnssHeading,
-            30 => INSError::WaitingForImuSync,
-            31 => INSError::StdDevExceedsLimit,
-            32 => INSError::UnsupportedSettings,
-            35 => INSError::IncorrectImuOrientation,
-            _ => INSError::None,
-        }
+#[allow(clippy::derivable_impls)]
+impl Default for INSError {
+    fn default() -> Self {
+        INSError::None
     }
 }
 

--- a/src/messages/pvt_geodetic.rs
+++ b/src/messages/pvt_geodetic.rs
@@ -1,13 +1,13 @@
-use binrw::BinRead;
 use alloc::vec::Vec;
+use binrw::BinRead;
 use bitflags::bitflags;
 use core::fmt;
+use num_enum::{FromPrimitive, IntoPrimitive};
 
 /// PVT mode (bits 0-3 of mode field).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive)]
 #[repr(u8)]
 pub enum PvtMode {
-    #[default]
     NoPvt = 0,
     StandAlone = 1,
     Differential = 2,
@@ -18,6 +18,8 @@ pub enum PvtMode {
     MovingBaseRtkFixed = 7,
     MovingBaseRtkFloat = 8,
     Ppp = 10,
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
 impl From<u8> for PvtMode {
@@ -33,7 +35,7 @@ impl From<u8> for PvtMode {
             7 => PvtMode::MovingBaseRtkFixed,
             8 => PvtMode::MovingBaseRtkFloat,
             10 => PvtMode::Ppp,
-            _ => PvtMode::NoPvt,
+            x => PvtMode::Unknown(x),
         }
     }
 }
@@ -51,6 +53,7 @@ impl fmt::Display for PvtMode {
             PvtMode::MovingBaseRtkFixed => write!(f, "Moving Base RTK Fixed"),
             PvtMode::MovingBaseRtkFloat => write!(f, "Moving Base RTK Float"),
             PvtMode::Ppp => write!(f, "PPP"),
+            PvtMode::Unknown(x) => write!(f, "Unknown({x})"),
         }
     }
 }
@@ -67,10 +70,9 @@ bitflags! {
 }
 
 /// Coordinate datum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum Datum {
-    #[default]
     Wgs84 = 0,
     /// Datum equal to that used by the DGNSS/RTK base station.
     DgnssBaseStation = 19,
@@ -92,33 +94,22 @@ pub enum Datum {
     UserDefined1 = 250,
     /// Second user-defined datum.
     UserDefined2 = 251,
-    Unknown,
+    /// Unrecognized datum code.
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
-impl From<u8> for Datum {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => Datum::Wgs84,
-            19 => Datum::DgnssBaseStation,
-            30 => Datum::Etrs89,
-            31 => Datum::Nad83_2011,
-            32 => Datum::Nad83Pa11,
-            33 => Datum::Nad83Ma11,
-            34 => Datum::Gda94,
-            35 => Datum::Gda2020,
-            36 => Datum::Jgd2011,
-            250 => Datum::UserDefined1,
-            251 => Datum::UserDefined2,
-            _ => Datum::Unknown,
-        }
+#[allow(clippy::derivable_impls)]
+impl Default for Datum {
+    fn default() -> Self {
+        Datum::Wgs84
     }
 }
 
 /// PVT error codes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum PvtError {
-    #[default]
     None = 0,
     NotEnoughMeasurements = 1,
     NotEnoughEphemerides = 2,
@@ -130,24 +121,14 @@ pub enum PvtError {
     NotEnoughDiffCorrections = 8,
     BaseCoordsUnavailable = 9,
     AmbiguitiesNotFixed = 10,
+    #[num_enum(catch_all)]
+    Unknown(u8),
 }
 
-impl From<u8> for PvtError {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => PvtError::None,
-            1 => PvtError::NotEnoughMeasurements,
-            2 => PvtError::NotEnoughEphemerides,
-            3 => PvtError::DopTooLarge,
-            4 => PvtError::ResidualsTooLarge,
-            5 => PvtError::NoConvergence,
-            6 => PvtError::NotEnoughAfterOutlierRejection,
-            7 => PvtError::PositionProhibited,
-            8 => PvtError::NotEnoughDiffCorrections,
-            9 => PvtError::BaseCoordsUnavailable,
-            10 => PvtError::AmbiguitiesNotFixed,
-            _ => PvtError::None,
-        }
+#[allow(clippy::derivable_impls)]
+impl Default for PvtError {
+    fn default() -> Self {
+        PvtError::None
     }
 }
 


### PR DESCRIPTION
Added `Unknown` variant to some enums and made the existing ones preserve the bad code.

Real bug: `INSError` and `PvtError` mapped all unknown non-zero codes to `NoError` because there was no `Unknown` variant in either one. Same with `PvtMode`. AdNav have septentrio devices that actually do have additional codes that they have shared with us, so `NoPvt` is not the right answer here either.

Enums that are exhaustive over the domain (e.g., values 0-3 stored in 2 bits were not modified.

I've added `num_enum` as a dependency here. It is tiny compared to some of our existing deps, and prevents the enum values from drifting with manual updates.

Keeping commit structure for logical flow until final merge. Will squash into a single commit before merging.